### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
+#For Clion IDE
 .idea/*
 cmake-build-debug/**
+
+#For Visual Studio Code IDE
+*/.vscode/.browse.c_cpp.db*
+*/.vscode/c_cpp_properties.json
+*/.vscode/launch.json
+
+#For the platformio plugin for Visual Studio Code
+*/.pio
+*/.pioenvs
+*/.piolibdeps
+
+#For RT-labs projects
+.metadata


### PR DESCRIPTION
ignores for clion, visual studio code, platformio and rt-labs slave editor